### PR TITLE
bsp/boards: use const struct for slot_board_vars intialization

### DIFF
--- a/bsp/boards/board.h
+++ b/bsp/boards/board.h
@@ -23,7 +23,36 @@ typedef enum {
    KICK_SCHEDULER        = 1,
 } kick_scheduler_t;
 
+#ifndef SLOTDURATION_20MS_24GHZ
+#define SLOTDURATION_20MS_24GHZ             20   /* in miliseconds */
+#endif
+#ifndef PORT_maxTxDataPrepare_20MS_24GHZ
+#define PORT_maxTxDataPrepare_20MS_24GHZ   110   /* 3355us (not measured) */
+#endif
+#ifndef PORT_maxRxAckPrepare_20MS_24GHZ
+#define PORT_maxRxAckPrepare_20MS_24GHZ    20    /*  610us (not measured) */
+#endif
+#ifndef PORT_maxRxDataPrepare_20MS_24GHZ
+#define PORT_maxRxDataPrepare_20MS_24GHZ   33    /* 1000us (not measured) */
+#endif
+#ifndef PORT_maxTxAckPrepare_20MS_24GHZ
+#define PORT_maxTxAckPrepare_20MS_24GHZ    50    /* 1525us (not measured) */
+#endif
+#ifndef PORT_delayTx_20MS_24GHZ
+#define PORT_delayTx_20MS_24GHZ            10   /*  549us (not measured) */
+#endif
+#ifndef PORT_delayRx_20MS_24GHZ
+#define PORT_delayRx_20MS_24GHZ            0    /*    0us (can not measure) */
+#endif
 
+#define SLOT_20MS_24GHZ_BOARD_VARS_DEFAULT  {  .slotDuration = SLOTDURATION_20MS_24GHZ, \
+                                           .maxTxDataPrepare = PORT_maxTxDataPrepare_20MS_24GHZ, \
+                                           .maxRxAckPrepare = PORT_maxRxAckPrepare_20MS_24GHZ, \
+                                           .maxRxAckPrepare = PORT_maxRxDataPrepare_20MS_24GHZ, \
+                                           .maxTxAckPrepare = PORT_maxTxAckPrepare_20MS_24GHZ, \
+                                           .delayTx = PORT_delayTx_20MS_24GHZ, \
+                                           .delayRx = PORT_delayRx_20MS_24GHZ, \
+                                           }
 
 //=========================== typedef =========================================
 typedef struct {
@@ -53,6 +82,15 @@ typedef enum{
 } slotType_t;
 
 //=========================== variables =======================================
+
+static const slot_board_vars_t slot_20ms_board_vars[] =
+{
+#ifdef SLOT_20MS_24GHZ_BOARD_VARS
+    SLOT_20MS_24GHZ_BOARD_VARS,
+#else
+    SLOT_20MS_24GHZ_BOARD_VARS_DEFAULT,
+#endif
+};
 
 //=========================== prototypes ======================================
 

--- a/bsp/boards/iot-lab_M3/board.c
+++ b/bsp/boards/iot-lab_M3/board.c
@@ -104,15 +104,9 @@ void board_init(void)
 
 //==== bootstrapping slot info lookup table
 void board_init_slot_vars(void){
-    
-    // 20ms slot
-    slot_board_vars [SLOT_20ms_24GHZ].slotDuration                   =  655   ; // ms  
-    slot_board_vars [SLOT_20ms_24GHZ].maxTxDataPrepare               =  110  ; //  3355us (not measured)
-    slot_board_vars [SLOT_20ms_24GHZ].maxRxAckPrepare                =  20   ; //   610us (not measured)
-    slot_board_vars [SLOT_20ms_24GHZ].maxRxDataPrepare               =  33   ; //  1000us (not measured)
-    slot_board_vars [SLOT_20ms_24GHZ].maxTxAckPrepare                =  50   ; //  1525us (not measured)
-    slot_board_vars [SLOT_20ms_24GHZ].delayTx                        =  18   ; //   549us (not measured)
-    slot_board_vars [SLOT_20ms_24GHZ].delayRx                        =  0    ; //     0us (can not measure)
+#ifdef SLOTDURATION_20MS_24GHZ
+    slot_board_vars [SLOT_20ms_24GHZ] = *slot_20ms_board_vars;
+#endif
 }
 
 // To get the current slotDuration at any time

--- a/bsp/boards/iot-lab_M3/board_info.h
+++ b/bsp/boards/iot-lab_M3/board_info.h
@@ -49,6 +49,23 @@ to return the board's description.
 #define PORT_PIN_RADIO_RESET_LOW()        //GPIOC->ODR &= ~0X0040;// nothing
 //#define PORT_PIN_RADIO_RESET_LOW()            GPIOC->ODR &= ~(1<<1);
 
+//===== IEEE802154E timing
+
+#define SLOTDURATION_20MS_24GHZ 20 // in miliseconds
+
+// time-slot related
+#define PORT_TsSlotDuration_20MS_24GHZ                 655   //    20ms
+
+// execution speed related
+#define PORT_maxTxDataPrepare_20MS_24GHZ               110   //  3355us (not measured)
+#define PORT_maxRxAckPrepare_20MS_24GHZ                20    //   610us (not measured)
+#define PORT_maxRxDataPrepare_20MS_24GHZ               33    //  1000us (not measured)
+#define PORT_maxTxAckPrepare_20MS_24GHZ                50    //  1525us (not measured)
+
+// radio speed related
+#define PORT_delayTx_20MS_24GHZ                        18    //   549us (not measured)
+#define PORT_delayRx_20MS_24GHZ                        0     //     0us (can not measure)
+// radio watchdog
 
 //===== adaptive_sync accuracy
 


### PR DESCRIPTION
This PR make a working example of the changes proposed in https://github.com/openwsn-berkeley/openwsn-fw/pull/504#discussion_r410117118 for `iot-lab_M3`.

Some advantages:

- default slot configuration can be provided in `bsp/boards/board.h` for all configurations, keeps configurations in headers.
- easily overridden in `bsp/<board>/board_info.h` when measured per board.
- slot vars can be initiated anywhere.
- migration should be easier, just change define names.
